### PR TITLE
Job Gift spells should always pass addendum check

### DIFF
--- a/tHotBar.lua
+++ b/tHotBar.lua
@@ -21,7 +21,7 @@
 
 addon.name      = 'tHotBar';
 addon.author    = 'Thorny';
-addon.version   = '1.18';
+addon.version   = '1.19';
 addon.desc      = 'Displays macros as visible and clickable elements.';
 addon.link      = 'https://ashitaxi.com/';
 
@@ -71,7 +71,7 @@ ashita.events.register('command', 'command_cb', function (e)
         end
         return;
     end
-    
+
     if (#args > 1) and (string.lower(args[2]) == 'palette') then
         gBindings:HandleCommand(args);
         return;
@@ -89,9 +89,9 @@ ashita.events.register('d3d_present', 'd3d_present_cb', function ()
     end
 
     gBindingGUI:Render();
-    
+
     gConfigGUI:Render();
-    
+
     if (gInterface ~= nil) then
         gInterface:Tick();
     end

--- a/updaters/spell.lua
+++ b/updaters/spell.lua
@@ -266,7 +266,7 @@ local function SubJobCheck(updater, jobData)
 end
 
 local function JobPointCheck(updater, jobData)
-    return (gPlayer:GetJobPointTotal(jobData.MainJob) >= updater.MainRequirement);
+    return (gPlayer:GetJobPointTotal(jobData.MainJob) >= updater.MainRequirement), true;
 end
 
 local function GetSpellAvailable(updater)


### PR DESCRIPTION
After unlocking Utsusemi: San I noticed it was always faded, and tracked that down to the difference between `MainJobCheck()` and `JobPointCheck()` in the spell updater.

As far as I'm aware no Job Gift spells are affected by addendums, so I've just got it always returning `true`. If this is a faulty assumption, I'm happy to mimic the logic performed by `MainJobCheck()` instead (or whatever is appropriate).